### PR TITLE
Saving 'init' tagged network when starting training

### DIFF
--- a/python/front_end/znetio.py
+++ b/python/front_end/znetio.py
@@ -70,7 +70,7 @@ def save_opts(opts, filename):
 
     f.close()
 
-def find_load_net( train_net, seed ):
+def find_load_net( train_net, seed=None ):
     if seed and os.path.exists(seed):
         fnet = seed
     else:
@@ -86,7 +86,7 @@ def get_current( filename ):
     filename_current = "{}{}{}".format(root, '_current', ext)
     return filename_current
 
-def save_network(network, filename, num_iters=None):
+def save_network(network, filename, num_iters=None, suffix=None):
     '''Saves a network under an h5 file. Appends the number
     of iterations if passed, and updates a "current" file with
     the most recent (uncorrupted) information'''
@@ -98,9 +98,13 @@ def save_network(network, filename, num_iters=None):
 
     filename_current = get_current(filename)
 
+    if suffix is not None:
+        root, ext = os.path.splitext(filename)
+        filename = "{}_{}{}".format(root, suffix, ext)
+
     if num_iters is not None:
         root, ext = os.path.splitext(filename)
-        filename = "{}{}{}{}".format(root, '_', num_iters, ext)
+        filename = "{}_{}{}".format(root, num_iters, ext)
 
     print "save as ", filename
     save_opts(network.get_opts(), filename)
@@ -300,7 +304,7 @@ def load_network( params=None, train=True, hdf5_filename=None,
         final_options = consolidate_opts(load_options, template_options, params)
 
     else:
-        print _hdf5filename, " do not exist, initialize a new network..."
+        print _hdf5_filename, " do not exist, initialize a new network..."
         final_options = template.get_opts()
         del template
 

--- a/python/train.py
+++ b/python/train.py
@@ -68,10 +68,9 @@ def main( args ):
     total_time = 0.0
     print "start from ", iter_last+1
 
-    #Saving initialized network
-    if iter_last+1 == 1:
-        znetio.save_network(net, pars['train_net'], num_iters=0)
-        lc.save( pars, 0.0 )
+    #Saving initial/seeded network
+    znetio.save_network(net, pars['train_net'], num_iters=iter_last, suffix="init")
+    lc.save( pars, 0.0, suffix="init_iter{}".format(iter_last) )
 
     for i in xrange(iter_last+1, pars['Max_iter']+1):
         # get random sub volume from sample

--- a/python/zstatistics.py
+++ b/python/zstatistics.py
@@ -217,12 +217,19 @@ class CLearnCurve:
         plt.show()
         return
 
-    def save(self, pars, elapsed):
+    def save(self, pars, elapsed, suffix=None):
         # get filename
         fname = pars['train_net']
         import os
         import shutil
+
         root, ext = os.path.splitext(fname)
+        #storing in case of a suffix,
+        # so 'current' file below isn't duplicated
+        orig_root = root
+        if suffix is not None:
+            root = "{}_{}".format(root, suffix)
+
         if len(self.tn_it) > 0:
             fname = root + '_statistics_{}.h5'.format( self.tn_it[-1] )
         else:
@@ -247,11 +254,11 @@ class CLearnCurve:
             f.create_dataset('/test/re',   data=self.tt_re )
             f.create_dataset('/test/mc',   data=self.tt_mc )
 
-        f.create_dataset('/elapsed',   data=elapsed)
+        f.create_dataset('/elapsed',   data=elapsed )
         f.close()
 
         # move to new name
-        fname2 = root + '_statistics_current.h5'
+        fname2 = orig_root + '_statistics_current.h5'
         if os.path.exists( fname2 ):
             os.remove( fname2 )
         shutil.copyfile(fname, fname2)


### PR DESCRIPTION
Always saves a network file upon starting a new training run, handling both seeding and full initializations. Each newly saved network is tagged with "init", but then overwrites the tagged "current" file under the output name.

Currently, this has the (slightly) odd behavior that it will overwrite the pure initialization if training is stopped before the first testing iteration. This behavior is ultimately due to the learning curve loading functionality, which also does not keep consistent records unless training passes the first testing iteration. If this is something we'd like to change, we can add a commit to handle the lc.get_last_it() functionality better.

Also fixes a typo error, and adds an explicit default argument to find_load_net to make the argument parsing logic more clear.