### PR TITLE
Cls error masking

### DIFF
--- a/python/config.cfg
+++ b/python/config.cfg
@@ -3,7 +3,7 @@
 # specification file of network architecture
 fnet_spec = ../networks/N4.znn
 # file of data spec
-fdata_spec = ../dataset/Piriform/dataset.spec
+fdata_spec = ../dataset/ISBI2012/dataset.spec
 # number of threads. if <=0, the thread number will be equal to
 # the number of concurrent threads supported by the implementation.
 num_threads = 0
@@ -18,10 +18,10 @@ logging = no
 # saved network file name. will automatically add iteration number
 # saved file name example: net_21000.h5, net_current.h5
 # the net_current.h5 will always be the latest network
-train_net = ../experiments/piriform/N4/net.h5
+train_net = ../experiments/ISBI/N4/net.h5
 # sample ID range for train
 # example: 2-3,7
-train_range = 2
+train_range = 1
 # sample ID range for validate/test during training
 # example: 1,4-6,8
 test_range = 1
@@ -39,7 +39,7 @@ train_conv_mode = fft
 
 # cost function: square_loss, binomial_cross_entropy, softmax_loss, auto
 # auto mode will match the out_type: boundary-softmax_loss, affinity-binomial_cross_entropy
-cost_fn = auto
+cost_fn = square_loss
 # use malis weighting of gradient
 # Maximin affinity learning of image segmentation
 # http://papers.nips.cc/paper/3887-maximin-affinity-learning-of-image-segmentation

--- a/python/front_end/zsample.py
+++ b/python/front_end/zsample.py
@@ -65,9 +65,6 @@ class CSample(object):
         if not is_forward:
             print "\ncreate label image class..."
             for name,setsz_out in self.setsz_outs.iteritems():
-                #Allowing for users to abstain from specifying labels
-                if not config.has_option(self.sec_name, name):
-                    continue
                 #Finding the section of the config file
                 imid = config.getint(self.sec_name, name)
                 imsec_name = "label%d" % (imid,)

--- a/python/test.py
+++ b/python/test.py
@@ -16,9 +16,9 @@ def _single_test(net, pars, sample):
     props = net.forward( vol_ins )
 
     # cost function and accumulate errors
-    props, err, grdts = pars['cost_fn']( props, lbl_outs )
+    props, err, grdts = pars['cost_fn']( props, lbl_outs, msks )
     # pixel classification error
-    cls = cost_fn.get_cls(props, lbl_outs)
+    cls = cost_fn.get_cls(props, lbl_outs, msks)
     # rand error
     re = pyznn.get_rand_error(props.values()[0], lbl_outs.values()[0])
 

--- a/python/train.py
+++ b/python/train.py
@@ -132,12 +132,12 @@ def main( args ):
         # cost function and accumulate errors
         props, cerr, grdts = pars['cost_fn']( props, lbl_outs, msks )
         err += cerr
-        cls += cost_fn.get_cls(props, lbl_outs)
+        cls += cost_fn.get_cls(props, lbl_outs, msks)
         # compute rand error
         if pars['is_debug']:
             assert not np.all(lbl_outs.values()[0]==0)
         re  += pyznn.get_rand_error( props.values()[0], lbl_outs.values()[0] )
-        num_mask_voxels += utils.sum_over_dict(msks)
+        num_mask_voxels += utils.get_total_num_mask(msks)
 
         # check whether there is a NaN here!
         if pars['is_debug']:
@@ -182,8 +182,8 @@ def main( args ):
                 err = err / vn / pars['Num_iter_per_show']
                 cls = cls / vn / pars['Num_iter_per_show']
             else:
-                err = err / num_mask_voxels / pars['Num_iter_per_show']
-                cls = cls / num_mask_voxels / pars['Num_iter_per_show']
+                err = err / num_mask_voxels
+                cls = cls / num_mask_voxels
             re = re / pars['Num_iter_per_show']
             lc.append_train(i, err, cls, re)
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -211,6 +211,19 @@ def get_total_num(outputs):
         n = n + np.prod(sz)
     return n
 
+
+def get_total_num_mask(masks, props=None):
+    '''Returns the total number of active voxels in a forward pass'''
+    s = 0
+    for name, mask in masks.iteritems():
+        #full mask can correspond to empty array
+        if mask.size == 0 and props is not None:
+            s += props[name].size
+        else:
+            s += mask.sum()
+    return s
+
+
 def sum_over_dict(dict_vol):
     s = 0
     for name, vol in dict_vol.iteritems():


### PR DESCRIPTION
Addressing #66 : Consistently applying mask across error computation, cls error, and testing error/cls

Two further commits:

- Allowing the config.cfg file to be used 'out of the box' by changing Piriform fields to ISBI2012
- Requiring users to specify labels for datasets used during training. This was originally allowed for the full forward pass, but causes a vague error message for training sets, and the full forward pass no longer uses this section of the code.