### PR TITLE
Removed librt from command line flags for OSX in makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIB_FLAGS	=
 MKL_FLAGS	=	-static-intel -mkl=sequential -DZNN_USE_MKL_FFT -DZNN_USE_MKL_NATIVE_FFT
 OPT_FLAGS	=	-DNDEBUG -O3 -std=c++1y -DZNN_CUBE_POOL_LOCKFREE -DZNN_USE_FLOATS
 OTH_FLAGS	=
-LIBS		=	-lfftw3 -lfftw3f -lpthread -pthread -lrt
+LIBS		=	-lfftw3 -lfftw3f -lpthread -pthread
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)


### PR DESCRIPTION
I was having trouble building some tests on OS X and noticed that lrt isn't used in OS X. In the makefile, the logic seems like it's trying to make sure it's only included on linux, so it seems like a typo to have it included by default.

I removed lrt and the code compiles now (though it still segfaults).